### PR TITLE
Remove errant comma

### DIFF
--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -31,7 +31,7 @@ namespace :load do
     set :slack_channel, '#general'
     set :slack_username, 'Capistrano'
     set :slack_emoji, ':ghost:'
-    set :slack_parse, 'default',
+    set :slack_parse, 'default'
     set :slack_user, -> { local_user.strip }
     set :slack_url, -> { Slackify::Configuration.instance.url }
     set :slack_text, lambda {


### PR DESCRIPTION
Looks like I accidentally dropped a comma in there when making revisions. Sorry about that.
