### PR TITLE
Enrich style of deploy finish/fail message

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Any of the defaults can be over-ridden in `config/deploy.rb`:
     set :slack_deploy_failed_text, -> {
       "#{fetch(:stage)} deploy of #{fetch(:application)} with revision/branch #{fetch(:current_revision, fetch(:branch))} failed"
     }
+    set :slack_deploy_finished_color, 'good'
+    set :slack_deploy_failed_color, 'danger'
 
 To configure the way slack parses your message (see 'Parsing Modes' at https://api.slack.com/docs/formatting) use the `:slack_parse` setting:
 

--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -26,7 +26,36 @@ namespace :slack do
       set :time_finished, Time.now.to_i
 
       payload = Slackify::Payload.build self do |default, context|
-        default[:text] = fetch(:slack_text)
+        text = fetch(:slack_text)
+        default[:attachments] = [
+          {
+            fallback: text,
+            color: '#439FE0',
+            text: text,
+            fields: [
+              {
+                title: 'Status',
+                value: 'success',
+                short: true
+              },
+              {
+                title: 'Stage',
+                value: fetch(:stage),
+                short: true
+              },
+              {
+                title: 'Branch',
+                value: fetch(:branch),
+                short: true
+              },
+              {
+                title: 'Revision',
+                value: fetch(:current_revision),
+                short: true
+              },
+            ]
+          }
+        ]
         default
       end
 
@@ -96,8 +125,7 @@ namespace :load do
     set :slack_url, -> { fail ':slack_url is not set' }
     set :slack_text, lambda {
       time_elapsed = Integer(fetch(:time_finished) - fetch(:time_started))
-      "Revision #{fetch(:current_revision, fetch(:branch))} of " \
-      "#{fetch(:application)} deployed to #{fetch(:stage)} by #{fetch(:slack_user)} " \
+      "#{fetch(:application)} deployed by #{fetch(:slack_user)} " \
       "in #{time_elapsed} seconds."
     }
     set :slack_deploy_starting_text, -> {

--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -50,7 +50,29 @@ namespace :slack do
           {
             fallback: text,
             color: 'danger',
-            text: text
+            text: text,
+            fields: [
+              {
+                title: 'Status',
+                value: 'failed',
+                short: true
+              },
+              {
+                title: 'Stage',
+                value: fetch(:stage),
+                short: true
+              },
+              {
+                title: 'Branch',
+                value: fetch(:branch),
+                short: true
+              },
+              {
+                title: 'Revision',
+                value: fetch(:current_revision),
+                short: true
+              },
+            ]
           }
         ]
         default
@@ -82,7 +104,7 @@ namespace :load do
       "#{fetch(:stage)} deploy starting with revision/branch #{fetch(:current_revision, fetch(:branch))} for #{fetch(:application)}"
     }
     set :slack_deploy_failed_text, -> {
-      "#{fetch(:stage)} deploy of #{fetch(:application)} with revision/branch #{fetch(:current_revision, fetch(:branch))} failed"
+      "deploy of #{fetch(:application)}"
     }
   end
 end

--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -45,7 +45,14 @@ namespace :slack do
       set :time_finished, Time.now.to_i
 
       payload = Slackify::Payload.build self do |default, context|
-        default[:text] = fetch :slack_deploy_failed_text
+        text = fetch :slack_deploy_failed_text
+        default[:attachments] = [
+          {
+            fallback: text,
+            color: 'danger',
+            text: text
+          }
+        ]
         default
       end
 

--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -5,8 +5,14 @@ namespace :slack do
     run_locally do
       info 'Notifying Slack of deploy starting'
       set :time_started, Time.now.to_i
+
+      payload = Slackify::Payload.build self do |default, context|
+        default[:text] = fetch(:slack_deploy_starting_text)
+        default
+      end
+
       execute :curl, '-X POST', '--data-urlencode',
-        Slackify::Payload.build(self, fetch(:slack_deploy_starting_text)),
+        payload,
         fetch(:slack_url)
     end
   end
@@ -18,8 +24,14 @@ namespace :slack do
     run_locally do
       info 'Notifying Slack of deploy finished'
       set :time_finished, Time.now.to_i
+
+      payload = Slackify::Payload.build self do |default, context|
+        default[:text] = fetch(:slack_text)
+        default
+      end
+
       execute :curl, '-X POST', '--data-urlencode',
-        Slackify::Payload.build(self, fetch(:slack_text)),
+        payload,
         fetch(:slack_url)
     end
   end
@@ -31,8 +43,14 @@ namespace :slack do
     run_locally do
       info 'Notifying Slack of deploy failed'
       set :time_finished, Time.now.to_i
+
+      payload = Slackify::Payload.build self do |default, context|
+        default[:text] = fetch :slack_deploy_failed_text
+        default
+      end
+
       execute :curl, '-X POST', '--data-urlencode',
-        Slackify::Payload.build(self, fetch(:slack_deploy_failed_text)),
+        payload,
         fetch(:slack_url)
     end
   end

--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -30,7 +30,7 @@ namespace :slack do
         default[:attachments] = [
           {
             fallback: text,
-            color: '#439FE0',
+            color: fetch(:slack_deploy_finished_color),
             text: text,
             fields: [
               {
@@ -78,7 +78,7 @@ namespace :slack do
         default[:attachments] = [
           {
             fallback: text,
-            color: 'danger',
+            color: fetch(:slack_deploy_failed_color),
             text: text,
             fields: [
               {
@@ -134,5 +134,7 @@ namespace :load do
     set :slack_deploy_failed_text, -> {
       "deploy of #{fetch(:application)}"
     }
+    set :slack_deploy_finished_color, 'good'
+    set :slack_deploy_failed_color, 'danger'
   end
 end

--- a/lib/slackify.rb
+++ b/lib/slackify.rb
@@ -3,29 +3,28 @@ require 'multi_json'
 module Slackify
   class Payload
 
-    attr_reader :text
-    protected :text
-
-    def initialize(context, text)
-      @context, @text = context, text
+    def initialize(context)
+      @context = context
     end
 
-    def self.build(context, text)
-      new(context, text).build
+    def self.build(context, &block)
+      new(context).build(&block)
     end
 
-    def build
-      "'payload=#{payload}'"
+    def build(&block)
+      "'payload=#{payload(&block)}'"
     end
 
-    def payload
-      MultiJson.dump({
+    def payload(&block)
+      default = {
         channel: fetch(:slack_channel),
         username: fetch(:slack_username),
-        text: text,
         icon_emoji: fetch(:slack_emoji),
         parse: fetch(:slack_parse)
-      })
+      }
+
+      json = yield(default, @context)
+      MultiJson.dump(json)
     end
 
     def fetch(*args, &block)

--- a/spec/lib/slackify_spec.rb
+++ b/spec/lib/slackify_spec.rb
@@ -15,13 +15,20 @@ module Slackify
       }
 
       let(:payload) {
-        %{'payload={"channel":"#general","username":"Capistrano","text":":boom:","icon_emoji":":ghost:","parse":"default"}'}
+        %{'payload={"channel":"#general","username":"Capistrano","icon_emoji":":ghost:","parse":"default","text":":boom:"}'}
       }
 
       let(:text) { context.fetch(:slack_text) }
 
+      let(:builded_payload) {
+        Payload.build context do |default, context|
+          default[:text] = text
+          default
+        end
+      }
+
       it 'returns the payload with the specified text' do
-        expect(Payload.build(context, text)).to eq payload
+        expect(builded_payload).to eq payload
       end
 
     end


### PR DESCRIPTION
First of all I appreciate  your useful gem, it's very useful and helps my daily work.

Sometimes it take a few seconds to recognize if a deployment failed or succeeded at a glance.
So I made some change to make them more recognizizable by
- color messages depending on the outcome status.
- separate status, stage, branch and revision into fields.
using the attachment feature of slack.

As a result the messages look like as bellow:

-----
![1432800389](https://cloud.githubusercontent.com/assets/1273434/7855480/076fe546-055d-11e5-9b5e-c6c848463004.png)
