### PR TITLE
Invokes "<scm>:set_current_revision" task before posting notifications

### DIFF
--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -2,6 +2,7 @@ namespace :slack do
   desc 'Notify Slack of a deployment via the incoming webhooks integration - ' \
        ':slack_subdomain and :slack_token must be set'
   task :notify_started do
+    invoke "#{scm}:set_current_revision"
     run_locally do
       set :time_started, Time.now.to_i
 


### PR DESCRIPTION
As a result `current_revision` variable is set at all times, avoiding empty `Revision` cell depicted below.

![screen shot 2015-09-01 at 08 42 09](https://cloud.githubusercontent.com/assets/988/9597785/8561a228-5085-11e5-80c4-fad6ff07e879.png)