### PR TITLE
Make it work with `cap <env> doctor`

### DIFF
--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -62,7 +62,7 @@ namespace :load do
     set :slack_hosts, -> { release_roles(:all).map(&:hostname).join("\n") }
     set :slack_url, -> { fail ':slack_url is not set' }
     set :slack_text, lambda {
-      time_elapsed = Integer(fetch(:time_finished) - fetch(:time_started))
+      time_elapsed = Integer(fetch(:time_finished, 0) - fetch(:time_started, 0))
       "#{fetch(:application)} deploy by #{fetch(:slack_user)}: " \
       "successful in #{time_elapsed} seconds."
     }


### PR DESCRIPTION
Otherwise using `doctor` command results in exception being thrown:
```
cap aborted!
NoMethodError: undefined method `-' for nil:NilClass
/[...]/gems/capistrano-slackify-2.7.0/lib/capistrano/tasks/slackify.cap:65:in `block (3 levels) in <top (required)>'
/[...]/gems/capistrano-3.5.0/lib/capistrano/configuration/variables.rb:51:in `peek'
/[...]/gems/capistrano-3.5.0/lib/capistrano/doctor/variables_doctor.rb:51:in `block in inspect_all_values'
/[...]/gems/capistrano-3.5.0/lib/capistrano/doctor/variables_doctor.rb:47:in `each'
/[...]/gems/capistrano-3.5.0/lib/capistrano/doctor/variables_doctor.rb:47:in `each_with_object'
/[...]/gems/capistrano-3.5.0/lib/capistrano/doctor/variables_doctor.rb:47:in `inspect_all_values'
/[...]/gems/capistrano-3.5.0/lib/capistrano/doctor/variables_doctor.rb:21:in `call'
/[...]/gems/capistrano-3.5.0/lib/capistrano/tasks/doctor.rake:17:in `block (2 levels) in <top (required)>'
/[...]/gems/rake-10.5.0/lib/rake/task.rb:240:in `block in execute'
/[...]/gems/rake-10.5.0/lib/rake/task.rb:235:in `each'
/[...]/gems/rake-10.5.0/lib/rake/task.rb:235:in `execute'
/[...]/gems/airbrussh-1.0.1/lib/airbrussh/rake/context.rb:55:in `execute'
/[...]/gems/rake-10.5.0/lib/rake/task.rb:179:in `block in invoke_with_call_chain'
/Users/sija/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
/[...]/gems/rake-10.5.0/lib/rake/task.rb:172:in `invoke_with_call_chain'
/[...]/gems/rake-10.5.0/lib/rake/task.rb:201:in `block in invoke_prerequisites'
/[...]/gems/rake-10.5.0/lib/rake/task.rb:199:in `each'
/[...]/gems/rake-10.5.0/lib/rake/task.rb:199:in `invoke_prerequisites'
/[...]/gems/rake-10.5.0/lib/rake/task.rb:178:in `block in invoke_with_call_chain'
/Users/sija/.rvm/rubies/ruby-2.3.1/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
/[...]/gems/rake-10.5.0/lib/rake/task.rb:172:in `invoke_with_call_chain'
/[...]/gems/rake-10.5.0/lib/rake/task.rb:165:in `invoke'
/[...]/gems/rake-10.5.0/lib/rake/application.rb:150:in `invoke_task'
/[...]/gems/rake-10.5.0/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/[...]/gems/rake-10.5.0/lib/rake/application.rb:106:in `each'
/[...]/gems/rake-10.5.0/lib/rake/application.rb:106:in `block in top_level'
/[...]/gems/rake-10.5.0/lib/rake/application.rb:115:in `run_with_threads'
/[...]/gems/rake-10.5.0/lib/rake/application.rb:100:in `top_level'
/[...]/gems/rake-10.5.0/lib/rake/application.rb:78:in `block in run'
/[...]/gems/rake-10.5.0/lib/rake/application.rb:176:in `standard_exception_handling'
/[...]/gems/rake-10.5.0/lib/rake/application.rb:75:in `run'
/[...]/gems/capistrano-3.5.0/lib/capistrano/application.rb:14:in `run'
./bin/cap:3:in `<main>'
Tasks: TOP => doctor => doctor:variables
```