### PR TITLE
Add the mrkdwn_in property to format on attachment fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Any of the defaults can be over-ridden in `config/deploy.rb`:
     set :slack_emoji, ':trollface:'
     set :slack_user, ENV['GIT_AUTHOR_NAME']
     set :slack_fields, ['status', 'stage', 'branch', 'revision', 'hosts']
+    set :slack_mrkdwn_in, ['pretext', 'text', 'fields']
     set :slack_hosts, -> { release_roles(:all).map(&:hostname).join("\n") }
     set :slack_text, -> {
       elapsed = Integer(fetch(:time_finished) - fetch(:time_started))

--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -59,6 +59,7 @@ namespace :load do
     set :slack_parse, 'default'
     set :slack_user, -> { local_user.strip }
     set :slack_fields, ['status', 'stage', 'branch', 'revision', 'hosts']
+    set :slack_mrkdwn_in, []
     set :slack_hosts, -> { release_roles(:all).map(&:hostname).join("\n") }
     set :slack_url, -> { fail ':slack_url is not set' }
     set :slack_text, lambda {

--- a/lib/slackify.rb
+++ b/lib/slackify.rb
@@ -63,6 +63,7 @@ module Slackify
               color: color,
               text: text,
               fields: fields,
+              mrkdwn_in: [fetch(:slack_mrkdwn_in)].flatten,
             }
           ]
         }

--- a/lib/slackify.rb
+++ b/lib/slackify.rb
@@ -63,7 +63,7 @@ module Slackify
               color: color,
               text: text,
               fields: fields,
-              mrkdwn_in: [fetch(:slack_mrkdwn_in)].flatten,
+              mrkdwn_in: fetch(:slack_mrkdwn_in),
             }
           ]
         }

--- a/spec/lib/slackify_spec.rb
+++ b/spec/lib/slackify_spec.rb
@@ -11,6 +11,7 @@ module Slackify
           slack_parse: 'default',
           slack_user: 'You',
           slack_fields: ['status', 'stage', 'branch', 'revision', 'hosts'],
+          slack_mrkdwn_in: ['text'],
           slack_hosts: "192.168.10.1\r192.168.10.2",
           slack_text: ':boom:',
           slack_deploy_finished_color: 'good',
@@ -21,7 +22,7 @@ module Slackify
       }
 
       let(:payload) {
-        %{'payload={"channel":"#general","username":"Capistrano","icon_emoji":":ghost:","parse":"default","attachments":[{"fallback":":boom:","color":"good","text":":boom:","fields":[{"title":"Status","value":"success","short":true},{"title":"Stage","value":"sandbox","short":true},{"title":"Branch","value":"master","short":true},{"title":"Revision","value":"SHA","short":true},{"title":"Hosts","value":"192.168.10.1\\r192.168.10.2","short":true}]}]}'}
+        %{'payload={"channel":"#general","username":"Capistrano","icon_emoji":":ghost:","parse":"default","attachments":[{"fallback":":boom:","color":"good","text":":boom:","fields":[{"title":"Status","value":"success","short":true},{"title":"Stage","value":"sandbox","short":true},{"title":"Branch","value":"master","short":true},{"title":"Revision","value":"SHA","short":true},{"title":"Hosts","value":"192.168.10.1\\r192.168.10.2","short":true}],"mrkdwn_in":["text"]}]}'}
       }
 
       let(:text) { context.fetch(:slack_text) }


### PR DESCRIPTION
By default attachment fields will not be formatted.
To enable it, set `mrkdwn_in` property on attachments.
See also https://api.slack.com/docs/formatting#message_formatting .