### PR TITLE
Allow custom fields to be passed into the slack_fields payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,32 @@ Any of the defaults can be over-ridden in `config/deploy.rb`:
     set :slack_deploy_failed_color, 'danger'
     set :slack_notify_events, [:started, :finished, :failed]
 
+You can setup custom fields by defining a mapping for how to display them in slack:
+
+    set :slack_fields, ['status', 'environment', 'docker_image']
+    # You could also add your custom mappings to the defaults with:
+    # set :slack_fields, fetch(:slack_fields).push('environment', 'docker_image')
+    set :slack_custom_field_mapping, -> {
+      {
+        'environment' => {
+          title: 'Environment',
+          value: -> {
+            if fetch(:stage) == :production
+              'production'
+            else
+              "staging-#{fetch(:staging_name)}"
+            end
+          },
+          short: true,
+        },
+        'docker_image' => {
+          title: 'Docker image',
+          value: fetch(:docker_image),
+          short: false,
+        },
+      }
+    }
+
 To configure the way slack parses your message (see 'Parsing Modes' at https://api.slack.com/docs/formatting) use the `:slack_parse` setting:
 
     set :slack_parse, 'none' # available options: 'default', 'none', 'full'

--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -59,6 +59,7 @@ namespace :load do
     set :slack_parse, 'default'
     set :slack_user, -> { local_user.strip }
     set :slack_fields, ['status', 'stage', 'branch', 'revision', 'hosts']
+    set :slack_custom_field_mapping, {}
     set :slack_mrkdwn_in, []
     set :slack_hosts, -> { release_roles(:all).map(&:hostname).join("\n") }
     set :slack_url, -> { fail ':slack_url is not set' }

--- a/spec/lib/slackify_spec.rb
+++ b/spec/lib/slackify_spec.rb
@@ -10,7 +10,21 @@ module Slackify
           slack_emoji: ':ghost:',
           slack_parse: 'default',
           slack_user: 'You',
-          slack_fields: ['status', 'stage', 'branch', 'revision', 'hosts'],
+          slack_fields: ['status', 'stage', 'branch', 'revision', 'hosts', 'custom_field', 'custom_field_with_proc'],
+          slack_custom_field_mapping: {
+            'custom_field' => {
+              title: 'custom title',
+              value: 'custom value',
+              short: false
+            },
+            'custom_field_with_proc' => {
+              title: 'custom title proc',
+              value: -> {
+                'custom value proc'
+              },
+              short: false
+            }
+          },
           slack_mrkdwn_in: ['text'],
           slack_hosts: "192.168.10.1\r192.168.10.2",
           slack_text: ':boom:',
@@ -22,7 +36,7 @@ module Slackify
       }
 
       let(:payload) {
-        %{'payload={"channel":"#general","username":"Capistrano","icon_emoji":":ghost:","parse":"default","attachments":[{"fallback":":boom:","color":"good","text":":boom:","fields":[{"title":"Status","value":"success","short":true},{"title":"Stage","value":"sandbox","short":true},{"title":"Branch","value":"master","short":true},{"title":"Revision","value":"SHA","short":true},{"title":"Hosts","value":"192.168.10.1\\r192.168.10.2","short":true}],"mrkdwn_in":["text"]}]}'}
+        %{'payload={"channel":"#general","username":"Capistrano","icon_emoji":":ghost:","parse":"default","attachments":[{"fallback":":boom:","color":"good","text":":boom:","fields":[{"title":"Status","value":"success","short":true},{"title":"Stage","value":"sandbox","short":true},{"title":"Branch","value":"master","short":true},{"title":"Revision","value":"SHA","short":true},{"title":"Hosts","value":"192.168.10.1\\r192.168.10.2","short":true},{"title":"custom title","value":"custom value","short":false},{"title":"custom title proc","value":"custom value proc","short":false}],"mrkdwn_in":["text"]}]}'}
       }
 
       let(:text) { context.fetch(:slack_text) }


### PR DESCRIPTION
Currently, you can only use the built in slack fields of:

```
['status', 'stage', 'branch', 'revision', 'hosts']
```

This change allows custom fields to be passed through by defining a
mapping of how to display them. e.g.

```
set :slack_fields, ['status', 'environment', 'docker_image']
set :slack_custom_field_mapping, -> {
  {
    'environment' => {
      title: 'Environment',
      value: -> {
        if fetch(:stage) == :production
          'production'
        else
          "staging-#{fetch(:staging_name)}"
        end
      },
      short: true,
    },
    'docker_image' => {
      title: 'Docker image',
      value: fetch(:docker_image),
      short: false,
    },
  }
}
```