### PR TITLE
Add to_s for local_user

### DIFF
--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -61,7 +61,7 @@ namespace :load do
     set :slack_username, 'Capistrano'
     set :slack_emoji, ':ghost:'
     set :slack_parse, 'default'
-    set :slack_user, -> { local_user.strip }
+    set :slack_user, -> { local_user.to_s.strip }
     set :slack_fields, ['status', 'stage', 'branch', 'revision', 'hosts']
     set :slack_custom_field_mapping, {}
     set :slack_mrkdwn_in, []


### PR DESCRIPTION
I added `to_s` because `local_user` is not always string. For example, in CircleCI.

Issue: #34 