### PR TITLE
Capistrano update parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can setup custom fields by defining a mapping for how to display them in sla
 
 To configure the way slack parses your message (see 'Parsing Modes' at https://api.slack.com/docs/formatting) use the `:slack_parse` setting:
 
-    set :slack_parse, 'none' # available options: 'default', 'none', 'full'
+    set :slack_parse, 'none' # available options: 'none', 'full'
 
 ### Copyright
 

--- a/lib/capistrano/tasks/slackify.cap
+++ b/lib/capistrano/tasks/slackify.cap
@@ -60,7 +60,7 @@ namespace :load do
     set :slack_channel, ['#general']
     set :slack_username, 'Capistrano'
     set :slack_emoji, ':ghost:'
-    set :slack_parse, 'default'
+    set :slack_parse, 'full'
     set :slack_user, -> { local_user.to_s.strip }
     set :slack_fields, ['status', 'stage', 'branch', 'revision', 'hosts']
     set :slack_custom_field_mapping, {}

--- a/spec/lib/slackify_spec.rb
+++ b/spec/lib/slackify_spec.rb
@@ -8,7 +8,7 @@ module Slackify
           slack_channel: '#general',
           slack_username: 'Capistrano',
           slack_emoji: ':ghost:',
-          slack_parse: 'default',
+          slack_parse: 'full',
           slack_user: 'You',
           slack_fields: ['status', 'stage', 'branch', 'revision', 'hosts', 'custom_field', 'custom_field_with_proc'],
           slack_custom_field_mapping: {
@@ -36,7 +36,7 @@ module Slackify
       }
 
       let(:payload) {
-        %{'payload={"channel":"#general","username":"Capistrano","icon_emoji":":ghost:","parse":"default","attachments":[{"fallback":":boom:","color":"good","text":":boom:","fields":[{"title":"Status","value":"success","short":true},{"title":"Stage","value":"sandbox","short":true},{"title":"Branch","value":"master","short":true},{"title":"Revision","value":"SHA","short":true},{"title":"Hosts","value":"192.168.10.1\\r192.168.10.2","short":true},{"title":"custom title","value":"custom value","short":false},{"title":"custom title proc","value":"custom value proc","short":false}],"mrkdwn_in":["text"]}]}'}
+        %{'payload={"channel":"#general","username":"Capistrano","icon_emoji":":ghost:","parse":"full","attachments":[{"fallback":":boom:","color":"good","text":":boom:","fields":[{"title":"Status","value":"success","short":true},{"title":"Stage","value":"sandbox","short":true},{"title":"Branch","value":"master","short":true},{"title":"Revision","value":"SHA","short":true},{"title":"Hosts","value":"192.168.10.1\\r192.168.10.2","short":true},{"title":"custom title","value":"custom value","short":false},{"title":"custom title proc","value":"custom value proc","short":false}],"mrkdwn_in":["text"]}]}'}
       }
 
       let(:text) { context.fetch(:slack_text) }


### PR DESCRIPTION
Previously, parse was set to 'default' however the only two options
allowed are 'full' or 'none'.

Resolves #36