### PR TITLE
Ensure the payload is shell escaped

### DIFF
--- a/lib/slackify.rb
+++ b/lib/slackify.rb
@@ -1,4 +1,5 @@
 require 'multi_json'
+require 'shellwords'
 
 module Slackify
   class Payload
@@ -13,7 +14,7 @@ module Slackify
     end
 
     def build(channel)
-      "'payload=#{payload(channel)}'"
+      Shellwords.escape("payload=#{payload(channel)}")
     end
 
     def payload(channel)

--- a/spec/lib/slackify_spec.rb
+++ b/spec/lib/slackify_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'shellwords'
 
 module Slackify
   describe Payload do
@@ -36,7 +37,7 @@ module Slackify
       }
 
       let(:payload) {
-        %{'payload={"channel":"#general","username":"Capistrano","icon_emoji":":ghost:","parse":"full","attachments":[{"fallback":":boom:","color":"good","text":":boom:","fields":[{"title":"Status","value":"success","short":true},{"title":"Stage","value":"sandbox","short":true},{"title":"Branch","value":"master","short":true},{"title":"Revision","value":"SHA","short":true},{"title":"Hosts","value":"192.168.10.1\\r192.168.10.2","short":true},{"title":"custom title","value":"custom value","short":false},{"title":"custom title proc","value":"custom value proc","short":false}],"mrkdwn_in":["text"]}]}'}
+        Shellwords.escape(%{payload={"channel":"#general","username":"Capistrano","icon_emoji":":ghost:","parse":"full","attachments":[{"fallback":":boom:","color":"good","text":":boom:","fields":[{"title":"Status","value":"success","short":true},{"title":"Stage","value":"sandbox","short":true},{"title":"Branch","value":"master","short":true},{"title":"Revision","value":"SHA","short":true},{"title":"Hosts","value":"192.168.10.1\\r192.168.10.2","short":true},{"title":"custom title","value":"custom value","short":false},{"title":"custom title proc","value":"custom value proc","short":false}],"mrkdwn_in":["text"]}]}})
       }
 
       let(:text) { context.fetch(:slack_text) }


### PR DESCRIPTION
Fixes #38 

I also used `Shellwords.escape` in the specs, because `Shellwords` is not pretty, and the payload would have looked something like:
```
payload\=\{\"channel\":\"\#general\",\"username\":\"Capistrano\",\"icon_emoji\..."custom\ value\ proc\",\"short\":false\}\],\"mrkdwn_in\":\[\"text\"\]\}\]\}
```
I can change back the spec to not call `Shellwords` if you want me to